### PR TITLE
win32: copy only necessary VC runtimes

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -47,9 +47,8 @@ install:
           throw "There are newer queued builds for this pull request, failing early." }
   - set OPENSSL_DIR="C:\OpenSSL-v11-Win%PYTHON_ARCH%"
   - set VCLIBDIR=%WINDIR%\System32
-  - cp %VCLIBDIR%/vcruntime*.dll ssh/
-  - cp %VCLIBDIR%/msvcp*.dll ssh/
-  - cp %VCLIBDIR%/msvcr*.dll ssh/
+  - cp %VCLIBDIR%/vcruntime140.dll ssh/
+  - cp %VCLIBDIR%/msvcr120.dll ssh/
   - cp %OPENSSL_DIR%/bin/*.dll ssh/
 
   - for %%I in (%PYTHONVERS%) do %%I\python.exe -V


### PR DESCRIPTION
Fixes #64 

Checked which imports the .pyds and ssh.dll + libcrypto/libssl have, seems to be the easiest way to figure this out. No idea why they link VCRUNTIME 140, but Visual C Runtime 120. Maybe the version numbers are just independent. These two DLLs also don't import any of the other DLLs we previously shipped.

Quick check says this should reduce the windows wheel size from 6.2 MB to 2.3 MB (**-60 %**).