### PR TITLE
docs: fix build on sphinx 8.x

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -121,7 +121,7 @@ html_sidebars = {
 
 # Output file base name for HTML help builder.
 htmlhelp_basename = 'ssh-pythondoc'
-intersphinx_mapping = {'https://docs.python.org/': None}
+intersphinx_mapping = {'python': ('https://docs.python.org/3', None)}
 autoclass_content = "both"
 
 # A list of files that should not be packed into the epub file.


### PR DESCRIPTION
More notes on the change required here: https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html

This was deprecated and now triggers an error:
```
WARNING: The pre-Sphinx 1.0 'intersphinx_mapping' format is deprecated and will be removed in Sphinx 8. Update to the current format as described in the documentation. Hint: "intersphinx_mapping = {'': ('https://docs.python.org/', None)}".https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html#confval-intersphinx_mapping
```