### PR TITLE
Stop using deprecated SafeConfigParser

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -145,6 +145,7 @@ workflows:
                 - "3.8"
                 - "3.9"
                 - "3.11"
+                - "3.12"
           filters:
             tags:
               ignore: /.*/

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -121,7 +121,7 @@ html_sidebars = {
 
 # Output file base name for HTML help builder.
 htmlhelp_basename = 'ssh-pythondoc'
-intersphinx_mapping = {'https://docs.python.org/': None}
+intersphinx_mapping = {'python': ('https://docs.python.org/', None)}
 autoclass_content = "both"
 
 # A list of files that should not be packed into the epub file.

--- a/versioneer.py
+++ b/versioneer.py
@@ -341,7 +341,7 @@ def get_config_from_root(root):
     setup_cfg = os.path.join(root, "setup.cfg")
     parser = configparser.ConfigParser()
     with open(setup_cfg, "r") as f:
-        parser.readfp(f)
+        parser.read_file(f)
     VCS = parser.get("versioneer", "VCS")  # mandatory
 
     def get(parser, name):

--- a/versioneer.py
+++ b/versioneer.py
@@ -339,7 +339,7 @@ def get_config_from_root(root):
     # configparser.NoOptionError (if it lacks "VCS="). See the docstring at
     # the top of versioneer.py for instructions on writing your setup.cfg .
     setup_cfg = os.path.join(root, "setup.cfg")
-    parser = configparser.SafeConfigParser()
+    parser = configparser.ConfigParser()
     with open(setup_cfg, "r") as f:
         parser.readfp(f)
     VCS = parser.get("versioneer", "VCS")  # mandatory


### PR DESCRIPTION
From Python 3.2.x until 3.11.x `SafeConfigParser` has been an alias for `ConfigParser`, but this has now been removed in Python 3.12.

In order to remain compatible with Python 3.12 onwards, this has now been updated to use `ConfigParser`.

More information is in: https://docs.python.org/3/whatsnew/changelog.html / https://github.com/python/cpython/pull/92503

Related to: #82